### PR TITLE
add: Link KHealth feature to HomeScreen

### DIFF
--- a/Frontend/composeApp/src/androidMain/kotlin/com/teamnotfound/airise/health/HealthDataProvider.kt
+++ b/Frontend/composeApp/src/androidMain/kotlin/com/teamnotfound/airise/health/HealthDataProvider.kt
@@ -6,13 +6,49 @@ import com.khealth.KHPermission
 import com.khealth.KHReadRequest
 import com.khealth.KHRecord
 import com.khealth.KHUnit
+import com.khealth.KHSleepStage
+import com.khealth.KHSleepStageSample
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.Instant
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+import kotlin.time.Duration.Companion.hours
 
 actual class HealthDataProvider actual constructor(private val kHealth: KHealth) {
+
+    private val SLEEPING_STAGES = setOf(
+        KHSleepStage.Sleeping,
+        KHSleepStage.REM,
+        KHSleepStage.Deep,
+        KHSleepStage.Light
+    )
+
+    // Sum only “sleep” stages and return hours (Double)
+    private fun KHRecord.SleepSession.totalSleepHours(): Double {
+        val totalMillis = samples
+            .asSequence()
+            .filter { it.stage in SLEEPING_STAGES }
+            .sumOf { s ->
+                val start = minOf(s.startTime, s.endTime)
+                val end = maxOf(s.startTime, s.endTime)
+                (end - start).inWholeMilliseconds
+            }
+
+        return totalMillis
+            .toDuration(DurationUnit.MILLISECONDS)
+            .toDouble(DurationUnit.HOURS)
+    }
+
+    // Pick the session that ends most recently (covers across-midnight nights)
+    private fun List<KHRecord>.mostRecentSleepSessionOrNull(): KHRecord.SleepSession? =
+        this.filterIsInstance<KHRecord.SleepSession>()
+            .maxByOrNull { sess ->
+                sess.samples.maxOfOrNull { it.endTime } ?: Instant.DISTANT_PAST
+            }
 
     // Request perm logic
     actual suspend fun requestPermissions(): Boolean {
@@ -20,7 +56,8 @@ actual class HealthDataProvider actual constructor(private val kHealth: KHealth)
         val permissionResponse: Set<KHPermission> = kHealth.requestPermissions(
             KHPermission.ActiveCaloriesBurned(read = true, write = true),
             KHPermission.HeartRate(read = true, write = true),
-            KHPermission.StepCount(read = true, write = true)
+            KHPermission.StepCount(read = true, write = true),
+            KHPermission.SleepSession(read = true, write = true)
             // Add as many requests as you want
         )
 
@@ -32,13 +69,16 @@ actual class HealthDataProvider actual constructor(private val kHealth: KHealth)
         // Init start and end time when fun is called
         val startTime = Clock.System.now().minus(1.days)
         val endTime = Clock.System.now()
+        val sleepStart = Clock.System.now() - 36.hours
 
         // Reading records
         val activeCaloriesRecord = kHealth.readRecords(KHReadRequest.ActiveCaloriesBurned(KHUnit.Energy.Calorie, startTime, endTime))
         val stepRecord = kHealth.readRecords(KHReadRequest.StepCount(startTime, endTime))
         val heartRateRecord = kHealth.readRecords(KHReadRequest.HeartRate(startTime, endTime))
+        val sleepRecord = kHealth.readRecords(KHReadRequest.SleepSession(sleepStart, endTime))
 
-        
+
+
         // Calculating Steps
         val steps = stepRecord.sumOf {
             (it as? KHRecord.StepCount)?.count?.toInt() ?: 0
@@ -59,16 +99,21 @@ actual class HealthDataProvider actual constructor(private val kHealth: KHealth)
             (it as? KHRecord.ActiveCaloriesBurned)?.value?.toInt() ?: 0
         }
 
+        // Last night’s sleep hours
+        val mostRecentSession = sleepRecord.mostRecentSleepSessionOrNull()
+        val sleepHours = mostRecentSession?.totalSleepHours() ?: 0.0
+
         // Passing to Health Data object for UI
         object : HealthData {
             override val activeCalories = activeCalories
             override val steps = steps
             override val heartRate = heartRate
+            override val sleepHours = sleepHours
         }
     }
 
     // Writing health data using Health Connect
-    actual suspend fun writeHealthData(): Boolean = withContext(Dispatchers.IO) {
+    actual suspend fun writeHealthData(): Boolean = withContext(Dispatchers.Default) {
 
         val sampleActiveCalories = KHRecord.ActiveCaloriesBurned(
             unit = KHUnit.Energy.Calorie,
@@ -88,10 +133,24 @@ actual class HealthDataProvider actual constructor(private val kHealth: KHealth)
                 KHHeartRateSample(beatsPerMinute = 135, time = Clock.System.now())
             ),
         )
+
+        // Create a small sleep sample (30 minutes) for testing increments
+        val sleepStartTime = Clock.System.now().minus(2.hours)
+        val sleepEndTime = Clock.System.now().minus(1.hours + 30.minutes)
+
+        val sampleSleep = KHRecord.SleepSession(
+            samples = listOf(
+                // Just 30 minutes of sleep for small increment testing
+                KHSleepStageSample(
+                    stage = KHSleepStage.Light,
+                    startTime = sleepStartTime,
+                    endTime = sleepEndTime,
+                )
+            ),
+        )
         // Add more sample data here
 
-        // Make sure to include samples here!
-        val result = kHealth.writeRecords(sampleActiveCalories, sampleHeartRate, sampleSteps)
+        val result = kHealth.writeRecords(sampleSteps, sampleHeartRate, sampleActiveCalories, sampleSleep)
         return@withContext result is com.khealth.KHWriteResponse.Success
     }
 }

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/App.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/App.kt
@@ -61,7 +61,7 @@ fun App(container: AppContainer) {
 
     LaunchedEffect(isUserLoggedIn) {
         if (isUserLoggedIn) {
-            navController.navigate(AppScreen.WORKOUT.name) { popUpTo(0) }
+            navController.navigate(AppScreen.HOMESCREEN.name) { popUpTo(0) }
         } else {
             navController.navigate(AppScreen.WELCOME.name) { popUpTo(0) }
         }
@@ -231,7 +231,7 @@ fun App(container: AppContainer) {
 
                 // Workout Screen
                 composable(route = AppScreen.WORKOUT.name) {
-                    WorkoutScreen(navController)
+                    WorkoutScreen()
                 }
 
                 //Navigation Bar and overview screen

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/App.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/App.kt
@@ -46,7 +46,7 @@ import com.teamnotfound.airise.community.friends.models.FriendsViewModel
 import com.teamnotfound.airise.community.leaderboard.LeaderboardScreen
 import com.teamnotfound.airise.community.leaderboard.LeaderboardViewModel
 import com.teamnotfound.airise.workout.WorkoutScreen
-
+import com.teamnotfound.airise.health.HealthDataProvider
 @Composable
 fun App(container: AppContainer) {
     val navController = rememberNavController()
@@ -82,7 +82,7 @@ fun App(container: AppContainer) {
 
     val sharedHomeVM: HomeViewModel = viewModel { HomeViewModel(
         UserRepository(auth = auth, container.userClient, container.userCache),
-        container.userClient
+        container.userClient, HealthDataProvider(container.kHealth)
     )}
 
     MaterialTheme {
@@ -188,7 +188,7 @@ fun App(container: AppContainer) {
                     route = AppScreen.HOMESCREEN.name,
                 ) {
                     HomeScreen(
-                        viewModel = HomeViewModel(userRepository, container.userClient),
+                        viewModel = HomeViewModel(userRepository, container.userClient, HealthDataProvider(container.kHealth)),
                         navController = navController
                     )
                 }

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/App.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/App.kt
@@ -231,7 +231,7 @@ fun App(container: AppContainer) {
 
                 // Workout Screen
                 composable(route = AppScreen.WORKOUT.name) {
-                    WorkoutScreen()
+                    WorkoutScreen(navController)
                 }
 
                 //Navigation Bar and overview screen

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/data/serializable/HealthData.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/data/serializable/HealthData.kt
@@ -6,10 +6,10 @@ import kotlinx.serialization.Serializable
 data class HealthData(
     val id: String = "",
     val userDataHealthId: String = "",
-    val sleep: Float = 0f,
+    val sleepHours: Double = 0.0,
     val steps: Int = 0,
     val caloriesBurned: Int = 0,
     val avgHeartRate: Int = 0,
     val workout: Int = 0,
-    val hydration: Float = 0f
+    val hydration: Float = 0f,
 )

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/generativeAi/GeminiApi.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/generativeAi/GeminiApi.kt
@@ -9,7 +9,6 @@ import dev.shreyaspatil.ai.client.generativeai.type.Content
 import dev.shreyaspatil.ai.client.generativeai.type.GenerateContentResponse
 import dev.shreyaspatil.ai.client.generativeai.type.PlatformImage
 import dev.shreyaspatil.ai.client.generativeai.type.content
-import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.Json
 import kotlin.math.roundToInt
 
@@ -74,7 +73,7 @@ class GeminiApi {
             if (h.steps > 0) add("steps=${h.steps}")
             if (h.workout > 0) add("workout_min=${h.workout}")
             if (h.caloriesBurned > 0) add("kcal_burned=${h.caloriesBurned}")
-            if (h.sleep > 0f) add("sleep_h=${h.sleep}")
+            if (h.sleepHours > 0f) add("sleep_h=${h.sleepHours}")
             if (h.avgHeartRate > 0) add("avg_hr=${h.avgHeartRate}")
             if (h.hydration > 0f) add("water_l=${h.hydration}")
         }

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/health/HealthDataProvider.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/health/HealthDataProvider.kt
@@ -6,6 +6,7 @@ interface HealthData {
     val activeCalories : Int
     val steps: Int
     val heartRate: Int
+    val sleepHours: Double
     // Add more fields as needed
 }
 

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/DailyProgress.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/DailyProgress.kt
@@ -23,10 +23,12 @@ import com.teamnotfound.airise.util.DeepBlue
 import com.teamnotfound.airise.util.NeonGreen
 import com.teamnotfound.airise.util.Orange
 import com.teamnotfound.airise.util.Silver
+import kotlin.math.floor
+import kotlin.math.roundToInt
 
 //Displays the daily progress section
 @Composable
-fun DailyProgressSection(dailyProgressData: DailyProgressData, isLoaded: Boolean) {
+fun DailyProgressSection(dailyProgressData: DailyProgressData, isLoaded: Boolean, lastNightSleepHours: Double? = null) {
 
     Column(
         modifier = Modifier
@@ -98,6 +100,14 @@ fun DailyProgressSection(dailyProgressData: DailyProgressData, isLoaded: Boolean
                 horizontalAlignment = Alignment.Start
             ) {
                 Legend(NeonGreen, "Sleep: ", dailyProgressData.sleepProgress.toInt())
+                if (isLoaded && lastNightSleepHours != null) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = "Last night: ${formatHours(lastNightSleepHours)}",
+                        fontSize = 11.sp,
+                        color = Silver
+                    )
+                }
                 Spacer(modifier = Modifier.height(6.dp))
                 Legend(Orange, "Workouts: ", dailyProgressData.workoutProgress.toInt())
                 Spacer(modifier = Modifier.height(6.dp))
@@ -147,3 +157,12 @@ fun DrawScope.drawProgressArc(
         size = Size(size.width - radiusOffset * 2, size.height - radiusOffset * 2)
     )
 }
+
+// Helper for formatting sleep hours
+
+private fun formatHours(hours: Double): String {
+    val h = floor(hours).toInt()
+    val m = ((hours - h) * 60).roundToInt().coerceIn(0, 59)
+    return if (h > 0) "${h}h ${m}m" else "${m}m"
+}
+

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/FitnessSummary.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/FitnessSummary.kt
@@ -147,15 +147,6 @@ fun FitnessSummarySection(
         }
 
         Spacer(modifier = Modifier.height(4.dp))
-        // Refresh button
-        Button(
-            onClick = onRefreshHealth,
-            colors = ButtonDefaults.buttonColors(backgroundColor = DeepBlue),
-            shape = RoundedCornerShape(180.dp),
-            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp)
-        ) { Text("Refresh", color = White, fontSize = 14.sp) }
-
-        Spacer(Modifier.width(8.dp))
 
         // Write sample
         Button(

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/FitnessSummary.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/FitnessSummary.kt
@@ -57,7 +57,9 @@ fun FitnessSummarySection(
     selectedTimeframe: String,
     formattedDate: String,
     healthData: HealthData,
-    onTimeFrameSelected: (String) -> Unit
+    onTimeFrameSelected: (String) -> Unit,
+    onRefreshHealth: () -> Unit,
+    onWriteSample: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -120,7 +122,6 @@ fun FitnessSummarySection(
                 }
             }
         }
-
         Spacer(modifier = Modifier.height(0.dp))
 
         // displays date in format
@@ -144,6 +145,25 @@ fun FitnessSummarySection(
             }
             HeartRateBox("Heart", healthData.avgHeartRate.toString(), "bpm", Modifier.weight(1.2f))
         }
+
+        Spacer(modifier = Modifier.height(4.dp))
+        // Refresh button
+        Button(
+            onClick = onRefreshHealth,
+            colors = ButtonDefaults.buttonColors(backgroundColor = DeepBlue),
+            shape = RoundedCornerShape(180.dp),
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp)
+        ) { Text("Refresh", color = White, fontSize = 14.sp) }
+
+        Spacer(Modifier.width(8.dp))
+
+        // Write sample
+        Button(
+            onClick = onWriteSample,
+            colors = ButtonDefaults.buttonColors(backgroundColor = DeepBlue),
+            shape = RoundedCornerShape(180.dp),
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp)
+        ) { Text("Write sample", color = White, fontSize = 14.sp) }
     }
 }
 

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/HomeScreen.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/HomeScreen.kt
@@ -33,6 +33,11 @@ fun HomeScreen(viewModel: HomeViewModel, navController: NavHostController) {
 
     val currentImageUrl = uiState.value.userProfilePicture
 
+    // Pull Apple/Android Health data when user lands here
+    LaunchedEffect(Unit) {
+        viewModel.syncHealthOnEnter()
+    }
+
     Scaffold(
         backgroundColor = BgBlack,
         bottomBar = {
@@ -115,7 +120,9 @@ fun HomeScreen(viewModel: HomeViewModel, navController: NavHostController) {
                     healthData = uiState.value.healthData,
                     onTimeFrameSelected = { timeFrame ->
                         viewModel.onEvent(HomeUiEvent.SelectedTimeFrameChanged(timeFrame))
-                    }
+                    },
+                    onRefreshHealth = { viewModel.syncHealthOnEnter() },
+                    onWriteSample = { viewModel.writeSampleHealth() }
                 )
             }
         }

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/HomeScreen.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/HomeScreen.kt
@@ -16,14 +16,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import com.teamnotfound.airise.data.repository.UserRepository
 import com.teamnotfound.airise.AppScreen
 import com.teamnotfound.airise.navigationBar.BottomNavigationBar
 import com.teamnotfound.airise.util.BgBlack
 import com.teamnotfound.airise.util.DeepBlue
 import com.teamnotfound.airise.util.White
-import dev.gitlive.firebase.Firebase
-import dev.gitlive.firebase.auth.auth
 
 
 @Composable
@@ -109,7 +106,8 @@ fun HomeScreen(viewModel: HomeViewModel, navController: NavHostController) {
 
                 DailyProgressSection(
                     dailyProgressData = uiState.value.dailyProgressData,
-                    isLoaded = uiState.value.isDailyProgressLoaded
+                    isLoaded = uiState.value.isDailyProgressLoaded,
+                    lastNightSleepHours = uiState.value.healthData.sleepHours
                     )
 
                 Spacer(modifier = Modifier.height(10.dp))

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/HomeViewModel.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/HomeViewModel.kt
@@ -12,7 +12,6 @@ import com.teamnotfound.airise.generativeAi.GeminiApi
 import com.teamnotfound.airise.health.HealthDataProvider
 import com.teamnotfound.airise.util.NetworkError
 import dev.gitlive.firebase.Firebase
-import dev.gitlive.firebase.auth.FirebaseUser
 import dev.gitlive.firebase.auth.auth
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -125,7 +124,7 @@ class HomeViewModel(private val userRepository: UserRepository,
             caloriesBurned = 0,
             steps = 0,
             avgHeartRate = 0,
-            sleep = 6.5f,
+            sleepHours = 6.5,
             workout = 3,
             hydration = 2850f
         )
@@ -151,7 +150,7 @@ class HomeViewModel(private val userRepository: UserRepository,
     private fun loadDailyProgress(){
         /* Needs to use respective goal to determine percentage,
          * instead of hard coded value */
-        val sleepPercentage = (todaysHealthData.sleep / 8f) * 100
+        val sleepPercentage = (todaysHealthData.sleepHours.toFloat() / 8f) * 100
         val workoutPercentage = (todaysHealthData.workout / 5f) * 100
         val hydrationPercentage = (todaysHealthData.hydration / 4000f) * 100
         val totalPercentage = (sleepPercentage + workoutPercentage + hydrationPercentage) / 3f
@@ -222,9 +221,9 @@ class HomeViewModel(private val userRepository: UserRepository,
                     caloriesBurned = platformHealth.activeCalories,
                     steps = platformHealth.steps,
                     avgHeartRate = platformHealth.heartRate,
-                    sleep =  todaysHealthData.sleep,   // TODO: wire actual sleep when added
-                    workout = todaysHealthData.workout, // TODO
-                    hydration = todaysHealthData.hydration // TODO
+                    sleepHours =  platformHealth.sleepHours,
+                    workout = todaysHealthData.workout, // TODO replace with .platformhealth
+                    hydration = todaysHealthData.hydration // TODO replace with .platformhealth
                 )
 
                 updatedHealthData = mapped

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/HomeViewModel.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/home/HomeViewModel.kt
@@ -228,6 +228,7 @@ class HomeViewModel(private val userRepository: UserRepository,
                 )
 
                 updatedHealthData = mapped
+                todaysHealthData = mapped
 
                 // Update UI
                 _uiState.value = _uiState.value.copy(
@@ -266,4 +267,11 @@ class HomeViewModel(private val userRepository: UserRepository,
             syncHealthOnEnter()
         }
     }
+
+    // Used for Unit testing
+    data class ProviderOverrides(
+        val requestPermissions: (suspend () -> Boolean)? = null,
+        val getMappedHealthData: (suspend () -> com.teamnotfound.airise.data.serializable.HealthData)? = null,
+        val writeHealthData: (suspend () -> Boolean)? = null
+    )
 }

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/workout/WorkoutScreen.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/workout/WorkoutScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import com.teamnotfound.airise.navigationBar.BottomNavigationBar
 
 @Composable
-fun WorkoutScreen() {
+fun WorkoutScreen(navController: NavHostController) {
     val viewModel: WorkoutViewModel = viewModel()
     val state by viewModel.uiState.collectAsState()
     val bottomNav = rememberNavController()

--- a/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/workout/WorkoutScreen.kt
+++ b/Frontend/composeApp/src/commonMain/kotlin/com/teamnotfound/airise/workout/WorkoutScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import com.teamnotfound.airise.navigationBar.BottomNavigationBar
 
 @Composable
-fun WorkoutScreen(navController: NavHostController) {
+fun WorkoutScreen() {
     val viewModel: WorkoutViewModel = viewModel()
     val state by viewModel.uiState.collectAsState()
     val bottomNav = rememberNavController()

--- a/Frontend/composeApp/src/commonTest/kotlin/HomeViewModelTest.kt
+++ b/Frontend/composeApp/src/commonTest/kotlin/HomeViewModelTest.kt
@@ -1,0 +1,42 @@
+import com.teamnotfound.airise.data.serializable.HealthData
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import com.teamnotfound.airise.home.HomeViewModel
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelKHealthTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun syncHealthOnEnter_usesMappedValues_fromOverrides() = runTest(dispatcher) {
+        val overrides = HomeViewModel.ProviderOverrides(
+            requestPermissions = { true },
+            getMappedHealthData = {
+                HealthData(
+                    caloriesBurned = 123,
+                    steps = 1200,
+                    avgHeartRate = 61,
+                    sleep = 6.5f,
+                    workout = 3,
+                    hydration = 2850f
+                )
+            }
+        )
+    }
+}

--- a/Frontend/composeApp/src/commonTest/kotlin/HomeViewModelTest.kt
+++ b/Frontend/composeApp/src/commonTest/kotlin/HomeViewModelTest.kt
@@ -32,7 +32,7 @@ class HomeViewModelKHealthTest {
                     caloriesBurned = 123,
                     steps = 1200,
                     avgHeartRate = 61,
-                    sleep = 6.5f,
+                    sleepHours = 6.5,
                     workout = 3,
                     hydration = 2850f
                 )


### PR DESCRIPTION
Linked KHealth to the HomeScreen

Testing Notes:
Since we are using emulators, a write data function has been utilized to write data to the HealthKit or HealthConnect.

**Test 1:**
Ensure HealthKit is enabled on iOS **or** install HealthConnect on Android.
Open the app to the overview screen
The overview should prompt the user for access to health data
Give some read and write data, but not all
It should prompt again when clicking the write data button
KHealth only gives the option to update Calories Burned, Steps, and Heart Rate. Heart Rate will remain at a fixed rate for now, while calories burned and steps should change each time the write data button is used

**Test 2**
Data should remain persistent, closing and reopening the app has no effect on Calories burned, Steps, and Heart Rate

**Test 3**
AI Prompt at the top updates when Write Data button is pushed.
